### PR TITLE
Enable HSTS preloading

### DIFF
--- a/troop89/settings/prod.py
+++ b/troop89/settings/prod.py
@@ -17,9 +17,7 @@ ALLOWED_HOSTS = [
 SECURE_SSL_REDIRECT = True
 
 # 31536000 seconds = one year minimum for preload lists
-# 3600 seconds = 1 hour for stability verification
-# 2592000 seconds = 1 month for stability verification
-SECURE_HSTS_SECONDS = 2592000
+SECURE_HSTS_SECONDS = 31536000
 
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 

--- a/troop89/settings/prod.py
+++ b/troop89/settings/prod.py
@@ -21,7 +21,7 @@ SECURE_HSTS_SECONDS = 31536000
 
 SECURE_HSTS_INCLUDE_SUBDOMAINS = True
 
-SECURE_HSTS_PRELOAD = False  # For temporary stability verification
+SECURE_HSTS_PRELOAD = True
 
 # CommonMiddleware settings
 


### PR DESCRIPTION
![Relative date](https://img.shields.io/date/1561939200.svg?label=planned%20merge)

While the Troop 89 website already implements [HTTP Strict-Transport-Security (HSTS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security), it does not satisfy the requirements for HSTS preloading. According to Google Chrome's [HSTS preload submission website](https://hstspreload.org/), the Troop 89 website cannot currently be preloaded since:

- The HSTS max-age value is too small (must be at least 31536000 seconds, or 1 year)
- The HSTS header does not contain the 'preload' directive

Each of these requirements are trivially satisfied by configuring the `SecurityMiddleware` settings.

In [release v0.15.0](https://github.com/blueschu/troop89medfield.org/releases/tag/v0.15.0), the max-age value in the HSTS header was set to 1 month as the final step in Google's [recommended deployment steps](https://hstspreload.org/#deployment-recommendations) for HSTS preloading. If no issues arrive by the end of June 2019, this PR will be merged into `development` and the Troop 89 will be registered for HSTS preloading shortly after the next release.